### PR TITLE
Fix file name for building EPUB

### DIFF
--- a/epub/book_data.json
+++ b/epub/book_data.json
@@ -5,7 +5,7 @@
     },
     {
         "chapter_root": "fix",
-        "code_supplements": ["benchmark.c", "fix.h", "fix.c"]
+        "code_supplements": ["benchmarks.c", "fix.h", "fix.c"]
     },
     {
         "chapter_root": "list",


### PR DESCRIPTION
A missing character was preventing the EPUB build script: `benchmark.c` -> `benchmarks.c`.