### PR TITLE
Move epub metadata to own file and update epub license to match repo license

### DIFF
--- a/epub/metadata.yml
+++ b/epub/metadata.yml
@@ -1,0 +1,14 @@
+---
+title:
+- type: main
+  text: Hacktical C
+creator:
+- role: author
+  text: Andreas Codr7
+identifier:
+# randomly generated URN; arbitrary but should be kept consistent so updates to
+# the book are recognized as the same book.
+- scheme: URN
+  text: urn:uuid:4eb54e25-66bf-4f42-9ee3-16fd2e7e1de5
+rights: Open License
+...

--- a/epub/metadata.yml
+++ b/epub/metadata.yml
@@ -10,5 +10,5 @@ identifier:
 # the book are recognized as the same book.
 - scheme: URN
   text: urn:uuid:4eb54e25-66bf-4f42-9ee3-16fd2e7e1de5
-rights: Open License
+rights: CC BY-NC-ND 4.0
 ...

--- a/epub/title.txt
+++ b/epub/title.txt
@@ -1,6 +1,0 @@
----
-title: Hacktical C
-author: Andreas Codr7
-rights: Open License
-language: en-US
-...


### PR DESCRIPTION
Move ePUB metadata generation to pre-defined file

The primary motivation is to make as much metadata specification consistent and not randomly generated by pandoc.

For now this is being used to keep a consistent URN across rebuilds. Some ebook readers make use of the URN to dedupe/auto-update books.

In the future it can be used to encode other ePUB metadata in an easy way.

Also corrects the now-outdated license line in the epub file